### PR TITLE
feat(giscus): added giscus comment system

### DIFF
--- a/src/components/Comments.astro
+++ b/src/components/Comments.astro
@@ -1,0 +1,18 @@
+<!-- Giscus comments -->
+
+<script is:inline src="https://giscus.app/client.js"
+        data-repo="pogor-dev/pogor.dev"
+        data-repo-id="R_kgDOLxGKaQ"
+        data-category="💬 Blog comments"
+        data-category-id="DIC_kwDOLxGKac4CoZ5Z"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="0"
+        data-input-position="top"
+        data-theme="dark_dimmed"
+        data-lang="en"
+        data-loading="lazy"
+        crossorigin="anonymous"
+        async>
+</script>

--- a/src/components/Comments.astro
+++ b/src/components/Comments.astro
@@ -1,18 +1,19 @@
 <!-- Giscus comments -->
-
-<script is:inline src="https://giscus.app/client.js"
-        data-repo="pogor-dev/pogor.dev"
-        data-repo-id="R_kgDOLxGKaQ"
-        data-category="💬 Blog comments"
-        data-category-id="DIC_kwDOLxGKac4CoZ5Z"
-        data-mapping="pathname"
-        data-strict="0"
-        data-reactions-enabled="1"
-        data-emit-metadata="0"
-        data-input-position="top"
-        data-theme="dark_dimmed"
-        data-lang="en"
-        data-loading="lazy"
-        crossorigin="anonymous"
-        async>
-</script>
+<script
+  is:inline
+  src="https://giscus.app/client.js"
+  data-repo="pogor-dev/pogor.dev"
+  data-repo-id="R_kgDOLxGKaQ"
+  data-category="💬 Blog comments"
+  data-category-id="DIC_kwDOLxGKac4CoZ5Z"
+  data-mapping="pathname"
+  data-strict="0"
+  data-reactions-enabled="1"
+  data-emit-metadata="0"
+  data-input-position="top"
+  data-theme="dark_dimmed"
+  data-lang="en"
+  data-loading="lazy"
+  crossorigin="anonymous"
+  async
+></script>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -13,6 +13,7 @@ import { slugifyStr } from "@/utils/slugify";
 import IconChevronLeft from "@/assets/icons/IconChevronLeft.svg";
 import IconChevronRight from "@/assets/icons/IconChevronRight.svg";
 import { SITE } from "@/config";
+import Comments from "@/components/Comments.astro";
 
 export interface Props {
   post: CollectionEntry<"blog">;
@@ -128,6 +129,10 @@ const nextPost =
     </div>
 
     <hr class="my-6 border-dashed" />
+
+    <Comments />
+
+    <hr class="my-8 border-dashed" />
 
     <!-- Previous/Next Post Buttons -->
     <div data-pagefind-ignore class="grid grid-cols-1 gap-6 sm:grid-cols-2">


### PR DESCRIPTION
This pull request adds a new commenting feature to the blog posts by integrating Giscus comments. The most important changes include adding the Giscus script to the `Comments.astro` component and updating the `PostDetails.astro` layout to include this new component.

Integration of Giscus comments:

* [`src/components/Comments.astro`](diffhunk://#diff-e0b624206a4b0dca091a648184dda1db8e9e4a02d82da4838bc72aeb50b2c05dR1-R18): Added the Giscus comments script to enable comments on blog posts.

Updates to post layout:

* [`src/layouts/PostDetails.astro`](diffhunk://#diff-a715a222a25309a700bbd78da2487a26184df587fd72b12ddc8fe3dd6b89ceadR16): Imported the `Comments` component and included it in the layout to display comments below each post. [[1]](diffhunk://#diff-a715a222a25309a700bbd78da2487a26184df587fd72b12ddc8fe3dd6b89ceadR16) [[2]](diffhunk://#diff-a715a222a25309a700bbd78da2487a26184df587fd72b12ddc8fe3dd6b89ceadR133-R136)